### PR TITLE
Fix doc generation inconsistencies across Python versions

### DIFF
--- a/src/lazydocs/generation.py
+++ b/src/lazydocs/generation.py
@@ -301,7 +301,16 @@ def _get_class_that_defined_method(meth: Any) -> Any:
 
 
 def _get_docstring(obj: Any) -> str:
-    return "" if obj.__doc__ is None else inspect.getdoc(obj) or ""
+    if obj.__doc__ is None:
+        return ""
+    doc = inspect.getdoc(obj) or ""
+    # Python 3.10 returns inherited Enum docstring "An enumeration.";
+    # Python 3.12+ returns None for enums without a custom docstring.
+    # Strip it for consistent output across Python versions.
+    if doc and inspect.isclass(obj) and issubclass(obj, Enum):
+        if doc == "An enumeration.":
+            return ""
+    return doc
 
 
 def _is_object_ignored(obj: Any) -> bool:
@@ -533,6 +542,15 @@ class MarkdownGenerator(object):
             if src_file == "<string>":
                 return ""
 
+            # Decorated functions (e.g., @deprecated from typing_extensions)
+            # may resolve to the decorator's module instead of the actual
+            # source. Try __wrapped__ to get the original function's source.
+            _wrapper_modules = ("typing_extensions", "typing", "functools")
+            if any(mod in src_file for mod in _wrapper_modules):
+                unwrapped = getattr(obj, "__wrapped__", None)
+                if unwrapped is not None:
+                    src_file = inspect.getsourcefile(unwrapped) or src_file
+
             path = os.path.abspath(src_file)
         except Exception:
             return ""
@@ -540,15 +558,7 @@ class MarkdownGenerator(object):
         assert isinstance(path, str)
 
         if src_root_path not in path:
-            # this can happen with e.g.
-            # inlinefunc-wrapped functions
-            if hasattr(obj, "__module__"):
-                path = "%s.%s" % (obj.__module__, obj.__name__)
-            else:
-                path = obj.__name__
-
-            assert isinstance(path, str)
-            path = path.replace(".", "/")
+            return ""
 
         src_path = Path(os.path.abspath(path)).relative_to(src_root_path).as_posix()
         if append_base and self.src_base_url:


### PR DESCRIPTION
## Summary
- Strip inherited "An enumeration." docstring from Enum classes without custom docstrings — Python 3.10 returns this via `Enum.__doc__`, while 3.12+ returns `None`, causing different output from the same source
- Handle decorated functions (e.g., `@deprecated` from `typing_extensions`) whose source resolves to the decorator's module instead of the actual source file — try `__wrapped__` to find the original function's source
- Return empty string instead of generating bogus source links when the resolved path falls outside the source root

## Context
These discrepancies cause `inv docs --check` CI failures in `robocorp/robocorp` when docs are generated on Python 3.12 locally but CI runs Python 3.10.

## Test plan
- Generate docs for a package with an Enum class (e.g., `robocorp-log` `FilterLogLevel`) on both Python 3.10 and 3.12 — output should be identical
- Generate docs for a package with `@deprecated` decorated functions (e.g., `robocorp-excel` `get_value`) on Python 3.12 — source link should not point to `typing_extensions.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)